### PR TITLE
When calling association.find RecordNotFound is now raised with the s…

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -3,7 +3,7 @@
 
     *Tinco Andringa*
 
-*   Add ActiveSupport::Notifications hook to Broadcaster#broadcast
+*   Add ActiveSupport::Notifications hook to Broadcaster#broadcast.
 
     *Matthew Wear*
 

--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+
 exit Minitest.run(ARGV)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -28,10 +28,10 @@
 
     *David Chen*
 
-*   Fix 'defaults' option for root route.
+*   Fix `defaults` option for root route.
 
     A regression from some refactoring for the 5.0 release, this change
-    fixes the use of 'defaults' (default parameters) in the 'root' routing method.
+    fixes the use of `defaults` (default parameters) in the `root` routing method.
 
     *Chris Arcand*
 
@@ -45,16 +45,16 @@
 
     *Grey Baker*
 
-*   Don't raise ActionController::UnknownHttpMethod from ActionDispatch::Static
+*   Don't raise `ActionController::UnknownHttpMethod` from `ActionDispatch::Static`.
 
     Pass `Rack::Request` objects to `ActionDispatch::FileHandler` to avoid it
     raising `ActionController::UnknownHttpMethod`. If an unknown method is
-    passed, it should exception higher in the stack instead, once we've had a
+    passed, it should pass exception higher in the stack instead, once we've had a
     chance to define exception handling behaviour.
 
     *Grey Baker*
 
-*   Handle `Rack::QueryParser` errors in `ActionDispatch::ExceptionWrapper`
+*   Handle `Rack::QueryParser` errors in `ActionDispatch::ExceptionWrapper`.
 
     Updated `ActionDispatch::ExceptionWrapper` to handle the Rack 2.0 namespace
     for `ParameterTypeError` and `InvalidParameterError` errors.

--- a/actionpack/bin/test
+++ b/actionpack/bin/test
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+
 exit Minitest.run(ARGV)

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -40,6 +40,7 @@ module ActionController
     autoload :Rescue
     autoload :Streaming
     autoload :StrongParameters
+    autoload :ParameterEncoding
     autoload :Testing
     autoload :UrlFor
   end

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -217,7 +217,7 @@ module ActionController
       MimeResponds,
       ImplicitRender,
       StrongParameters,
-
+      ParameterEncoding,
       Cookies,
       Flash,
       FormBuilder,

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -139,6 +139,10 @@ module ActionController
       end
     end
 
+    def self.encoding_for_param(action, param) # :nodoc:
+      ::Encoding::UTF_8
+    end
+
     # Delegates to the class' <tt>controller_name</tt>
     def controller_name
       self.class.controller_name

--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -1,0 +1,29 @@
+module ActionController
+  module ParameterEncoding
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def inherited(klass)
+        super
+        klass.setup_param_encode
+      end
+
+      def setup_param_encode
+        @_parameter_encodings = {}
+      end
+
+      def encoding_for_param(action, param)
+        if @_parameter_encodings[action.to_s] && @_parameter_encodings[action.to_s][param.to_s]
+          @_parameter_encodings[action.to_s][param.to_s]
+        else
+          ::Encoding::UTF_8
+        end
+      end
+
+      def parameter_encoding(action, param_name, encoding)
+        @_parameter_encodings[action.to_s] ||= {}
+        @_parameter_encodings[action.to_s][param_name.to_s] = encoding
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -1,4 +1,5 @@
 module ActionController
+  # Allows encoding to be specified per parameter per action.
   module ParameterEncoding
     extend ActiveSupport::Concern
 

--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -4,16 +4,16 @@ module ActionController
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def inherited(klass)
+      def inherited(klass) # :nodoc:
         super
         klass.setup_param_encode
       end
 
-      def setup_param_encode
+      def setup_param_encode # :nodoc:
         @_parameter_encodings = {}
       end
 
-      def encoding_for_param(action, param)
+      def encoding_for_param(action, param) # :nodoc:
         if @_parameter_encodings[action.to_s] && @_parameter_encodings[action.to_s][param.to_s]
           @_parameter_encodings[action.to_s][param.to_s]
         else

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -668,11 +668,6 @@ module ActionController
             end
           end
         end
-
-        def html_format?(parameters)
-          return true unless parameters.key?(:format)
-          Mime.fetch(parameters[:format]) { Mime["html"] }.html?
-        end
     end
 
     include Behavior

--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -3,7 +3,7 @@ module ActionDispatch
     # Provides access to the request's HTTP headers from the environment.
     #
     #   env     = { "CONTENT_TYPE" => "text/plain", "HTTP_USER_AGENT" => "curl/7.43.0" }
-    #   headers = ActionDispatch::Http::Headers.new(env)
+    #   headers = ActionDispatch::Http::Headers.from_hash(env)
     #   headers["Content-Type"] # => "text/plain"
     #   headers["User-Agent"] # => "curl/7.43.0"
     #

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -43,17 +43,6 @@ module ActionDispatch
       end
       alias :params :parameters
 
-      def set_custom_encoding(params)
-        action = params[:action]
-        params.each do |k, v|
-          if v.is_a?(String) && v.encoding != encoding_template(action, k)
-            params[k] = v.force_encoding(encoding_template(action, k))
-          end
-        end
-
-        params
-      end
-
       def path_parameters=(parameters) #:nodoc:
         delete_header("action_dispatch.request.parameters")
 
@@ -75,6 +64,17 @@ module ActionDispatch
       end
 
       private
+
+        def set_custom_encoding(params)
+          action = params[:action]
+          params.each do |k, v|
+            if v.is_a?(String) && v.encoding != encoding_template(action, k)
+              params[k] = v.force_encoding(encoding_template(action, k))
+            end
+          end
+
+          params
+        end
 
         def encoding_template(action, param)
           controller_class.encoding_for_param(action, param)

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -69,6 +69,7 @@ module ActionDispatch
     PASS_NOT_FOUND = Class.new { # :nodoc:
       def self.action(_); self; end
       def self.call(_); [404, {"X-Cascade" => "pass"}, []]; end
+      def self.encoding_for_param(action, param); ::Encoding::UTF_8; end
     }
 
     def controller_class

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -184,7 +184,7 @@ module ActionDispatch
           end
 
           # Assume given controller
-          request = ActionController::TestRequest.create
+          request = ActionController::TestRequest.create @controller.class
 
           if path =~ %r{://}
             fail_on(URI::InvalidURIError, msg) do

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -9,7 +9,8 @@ module AbstractController
     class TranslationControllerTest < ActiveSupport::TestCase
       def setup
         @controller = TranslationController.new
-        I18n.backend.store_translations(:en,           one: {
+        I18n.backend.store_translations(:en,
+          one: {
             two: "bar",
           },
           abstract_controller: {

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -122,27 +122,19 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
     # Stub Rails dispatcher so it does not get controller references and
     # simply return the controller#action as Rack::Body.
     class NullController < ::ActionController::Metal
-      def initialize(controller_name)
-        @controller = controller_name
-      end
-
-      def make_response!(request)
-        self.class.make_response! request
-      end
-
-      def dispatch(action, req, res)
-        [200, {"Content-Type" => "text/html"}, ["#{@controller}##{action}"]]
+      def self.dispatch(action, req, res)
+        [200, {"Content-Type" => "text/html"}, ["#{req.params[:controller]}##{action}"]]
       end
     end
 
-    class NullControllerRequest < DelegateClass(ActionDispatch::Request)
+    class NullControllerRequest < ActionDispatch::Request
       def controller_class
-        NullController.new params[:controller]
+        NullController
       end
     end
 
     def make_request(env)
-      NullControllerRequest.new super
+      NullControllerRequest.new env
     end
   end
 

--- a/actionpack/test/controller/new_base/render_action_test.rb
+++ b/actionpack/test/controller/new_base/render_action_test.rb
@@ -258,7 +258,8 @@ end
 
 module RenderActionWithBothLayouts
   class BasicController < ActionController::Base
-    self.view_paths = [ActionView::FixtureResolver.new(      "render_action_with_both_layouts/basic/hello_world.html.erb" => "Hello World!",
+    self.view_paths = [ActionView::FixtureResolver.new(
+      "render_action_with_both_layouts/basic/hello_world.html.erb"  => "Hello World!",
       "layouts/application.html.erb"                                => "Oh Hi <%= yield %> Bye",
       "layouts/render_action_with_both_layouts/basic.html.erb"      => "With Controller Layout! <%= yield %> Bye")]
 

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -1,0 +1,73 @@
+require "abstract_unit"
+
+class ParameterEncodingController < ActionController::Base
+  parameter_encoding :test_bar,          :bar, Encoding::ASCII_8BIT
+  parameter_encoding :test_baz,          :baz, Encoding::ISO_8859_1
+  parameter_encoding :test_baz_to_ascii, :baz, Encoding::ASCII_8BIT
+
+  def test_foo
+    render body: params[:foo].encoding
+  end
+
+  def test_bar
+    render body: params[:bar].encoding
+  end
+
+  def test_baz
+    render body: params[:baz].encoding
+  end
+
+  def test_no_change_to_baz
+    render body: params[:baz].encoding
+  end
+
+  def test_baz_to_ascii
+    render body: params[:baz].encoding
+  end
+end
+
+class ParameterEncodingTest < ActionController::TestCase
+  tests ParameterEncodingController
+
+  test "properly transcodes UTF8 parameters into declared encodings" do
+    post :test_foo, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "UTF-8", @response.body
+  end
+
+  test "properly transcodes ASCII_8BIT parameters into declared encodings" do
+    post :test_bar, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "ASCII-8BIT", @response.body
+  end
+
+  test "properly transcodes ISO_8859_1 parameters into declared encodings" do
+    post :test_baz, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "ISO-8859-1", @response.body
+  end
+
+  test "does not transcode parameters when not specified" do
+    post :test_no_change_to_baz, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "UTF-8", @response.body
+  end
+
+  test "respects different encoding declarations for a param per action" do
+    post :test_baz_to_ascii, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "ASCII-8BIT", @response.body
+  end
+
+  test "does not raise an error when passed a param declared as ASCII-8BIT that contains invalid bytes" do
+    get :test_bar, params: { "bar" => URI.parser.escape("bar\xE2baz".b) }
+
+    assert_response :success
+    assert_equal "ASCII-8BIT", @response.body
+  end
+end

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -19,7 +19,8 @@ class AlwaysPermittedParametersTest < ActiveSupport::TestCase
   end
 
   test "permits parameters that are whitelisted" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       format: "json")
     permitted = params.permit book: [:pages]
     assert permitted.permitted?

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -11,7 +11,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected param" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       fishing: "Turnips")
 
     assert_logged("Unpermitted parameter: fishing") do
@@ -20,7 +21,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected params" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       fishing: "Turnips",
       car: "Mersedes")
 
@@ -30,7 +32,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected nested param" do
-    params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then." })
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then." })
 
     assert_logged("Unpermitted parameter: title") do
       params.permit(book: [:pages])
@@ -38,7 +41,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected nested params" do
-    params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then.", author: "G. A. Dog" })
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then.", author: "G. A. Dog" })
 
     assert_logged("Unpermitted parameters: title, author") do
       params.permit(book: [:pages])

--- a/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
+++ b/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
@@ -3,7 +3,8 @@ require "action_controller/metal/strong_parameters"
 
 class MultiParameterAttributesTest < ActiveSupport::TestCase
   test "permitted multi-parameter attribute keys" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         "shipped_at(1i)"   => "2012",
         "shipped_at(2i)"   => "3",
         "shipped_at(3i)"   => "25",

--- a/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
@@ -7,7 +7,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permitted nested parameters" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         title: "Romeo and Juliet",
         authors: [{
           name: "William Shakespeare",
@@ -43,7 +44,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permitted nested parameters with a string or a symbol as a key" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         "authors" => [
           { name: "William Shakespeare", born: "1564-04-26" },
           { name: "Christopher Marlowe" }
@@ -66,7 +68,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested arrays with strings" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         genres: ["Tragedy"]
       })
 
@@ -75,7 +78,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permit may specify symbols or strings" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         title: "Romeo and Juliet",
         author: "William Shakespeare"
       },
@@ -88,7 +92,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested array with strings that should be hashes" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         genres: ["Tragedy"]
       })
 
@@ -97,7 +102,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested array with strings that should be hashes and additional values" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         title: "Romeo and Juliet",
         genres: ["Tragedy"]
       })
@@ -108,7 +114,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested string that should be a hash" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         genre: "Tragedy"
       })
 
@@ -117,7 +124,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "fields_for-style nested params" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         authors_attributes: {
           '0': { name: "William Shakespeare", age_of_death: "52" },
           '1': { name: "Unattributed Assistant" },
@@ -136,7 +144,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "fields_for-style nested params with negative numbers" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         authors_attributes: {
           '-1': { name: "William Shakespeare", age_of_death: "52" },
           '-2': { name: "Unattributed Assistant" }
@@ -153,7 +162,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested number as key" do
-    params = ActionController::Parameters.new(      product: {
+    params = ActionController::Parameters.new(
+      product: {
         properties: {
           "0" => "prop0",
           "1" => "prop1"

--- a/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
@@ -11,7 +11,8 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "raises on unexpected params" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       fishing: "Turnips")
 
     assert_raises(ActionController::UnpermittedParameters) do
@@ -20,7 +21,8 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "raises on unexpected nested params" do
-    params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then." })
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then." })
 
     assert_raises(ActionController::UnpermittedParameters) do
       params.permit(book: [:pages])

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -29,7 +29,8 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
 
   def test_route_generation_escapes_unsafe_path_characters
     assert_equal "/content/act#{@escaped}ion/var#{@escaped}iable/add#{@escaped}itional-1/add#{@escaped}itional-2",
-      url_for(@set,         controller: "content",
+      url_for(@set,
+        controller: "content",
         action: "act#{@segment}ion",
         variable: "var#{@segment}iable",
         additional: ["add#{@segment}itional-1", "add#{@segment}itional-2"])
@@ -45,7 +46,8 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
 
   def test_route_generation_allows_passing_non_string_values_to_generated_helper
     assert_equal "/content/action/variable/1/2",
-      url_for(@set,         controller: "content",
+      url_for(@set,
+        controller: "content",
         action: "action",
         variable: "variable",
         additional: [1, 2])
@@ -776,7 +778,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "/journal", url_for(rs,       controller: "content",
+    assert_equal "/journal", url_for(rs,
+      controller: "content",
       action: "list_journal",
       date: nil,
       user_id: nil)

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -50,7 +50,8 @@ module ActionDispatch
         path  = Path::Pattern.from_string "/:controller/*extra"
         route = Route.build("name", nil, path, {}, [],
                           controller: "foo", action: "bar")
-        assert_equal "/foo/himom", route.format(          controller: "foo",
+        assert_equal "/foo/himom", route.format(
+          controller: "foo",
           extra: "himom")
       end
 
@@ -58,7 +59,8 @@ module ActionDispatch
         path  = Path::Pattern.from_string "/:controller(/:action(/:id(.:format)))"
         route = Route.build("name", nil, path, {action: "bar"}, [], controller: "foo")
 
-        assert_equal "/foo/bar/10", route.format(          controller: "foo",
+        assert_equal "/foo/bar/10", route.format(
+          controller: "foo",
           action: "bar",
           id: 10)
       end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -61,7 +61,7 @@
 *   Change `datetime_field` and `datetime_field_tag` to generate `datetime-local` fields.
 
     As a new specification of the HTML 5 the text field type `datetime` will no longer exist
-    and it is recomended to use `datetime-local`.
+    and it is recommended to use `datetime-local`.
     Ref: https://html.spec.whatwg.org/multipage/forms.html#local-date-and-time-state-(type=datetime-local)
 
     *Herminio Torres*

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+
 exit Minitest.run(ARGV)

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -90,7 +90,7 @@ module ActionView
           else
             value = escape ? ERB::Util.unwrapped_html_escape(value) : value
           end
-          %(#{key}="#{value}")
+          %(#{key}="#{value.gsub(/"/, '&quot;'.freeze)}")
         end
 
         private

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -88,7 +88,7 @@ module ActionView
           if value.is_a?(Array)
             value = escape ? safe_join(value, " ") : value.join(" ")
           else
-            value = escape ? ERB::Util.unwrapped_html_escape(value) : value
+            value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
           end
           %(#{key}="#{value.gsub(/"/, '&quot;'.freeze)}")
         end

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -24,7 +24,7 @@ module ActionView
       def initialize
         super
         self.class.controller_path = ""
-        @request = ActionController::TestRequest.create
+        @request = ActionController::TestRequest.create(self.class)
         @response = ActionDispatch::TestResponse.new
 
         @request.env.delete("PATH_INFO")

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -131,7 +131,7 @@ class ViewLoadPathsTest < ActionController::TestCase
             "Decorated body",
             template.identifier,
             template.handler,
-                          virtual_path: template.virtual_path,
+              virtual_path: template.virtual_path,
               format: template.formats
           )
         end

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -23,9 +23,9 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def setup
-    @request  = ActionController::TestRequest.create
-    @response = ActionDispatch::TestResponse.new
     @controller = TestController.new
+    @request  = ActionController::TestRequest.create(@controller.class)
+    @response = ActionDispatch::TestResponse.new
     @paths = TestController.view_paths
   end
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -16,7 +16,8 @@ class FormHelperTest < ActionView::TestCase
 
   setup do
     # Create "label" locale for testing I18n label helpers
-    I18n.backend.store_translations "label",       activemodel: {
+    I18n.backend.store_translations "label",
+      activemodel: {
         attributes: {
           post: {
             cost: "Total cost"
@@ -47,7 +48,8 @@ class FormHelperTest < ActionView::TestCase
       }
 
     # Create "submit" locale for testing I18n submit helpers
-    I18n.backend.store_translations "submit",       helpers: {
+    I18n.backend.store_translations "submit",
+      helpers: {
         submit: {
           create: "Create %{model}",
           update: "Confirm %{model} changes",
@@ -58,7 +60,8 @@ class FormHelperTest < ActionView::TestCase
         }
       }
 
-    I18n.backend.store_translations "placeholder",       activemodel: {
+    I18n.backend.store_translations "placeholder",
+      activemodel: {
         attributes: {
           post: {
             cost: "Total cost"

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -59,6 +59,14 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p included=\"\"></p>", tag.p(included: "")
   end
 
+  def test_tag_options_accepts_symbol_option_when_not_escaping
+    assert_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
+  end
+
+  def test_tag_options_accepts_integer_option_when_not_escaping
+    assert_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
+  end
+
   def test_tag_options_converts_boolean_option
     assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" />',
       tag("p", disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -274,6 +274,16 @@ class TagHelperTest < ActionView::TestCase
     assert_equal '<p class="song> play&gt;"></p>', tag.p(class: [raw("song>"), "play>"])
   end
 
+  def test_tag_does_not_honor_html_safe_double_quotes_as_attributes
+    assert_dom_equal '<p title="&quot;">content</p>',
+      content_tag('p', "content", title: '"'.html_safe)
+  end
+
+  def test_data_tag_does_not_honor_html_safe_double_quotes_as_attributes
+    assert_dom_equal '<p data-title="&quot;">content</p>',
+      content_tag('p', "content", data: { title: '"'.html_safe })
+  end
+
   def test_skip_invalid_escaped_attributes
     ["&1;", "&#1dfa3;", "& #123;"].each do |escaped|
       assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", href: escaped)

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Rails 5.1.0.alpha ##
 
-*   Added declarative exception handling via ActiveJob::Base.retry_on and ActiveJob::Base.discard_on. 
+*   Added declarative exception handling via `ActiveJob::Base.retry_on` and `ActiveJob::Base.discard_on`. 
 
     Examples:
 

--- a/activemodel/bin/test
+++ b/activemodel/bin/test
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+
 exit Minitest.run(ARGV)

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -439,7 +439,8 @@ module ActiveModel
       return message if attribute == :base
       attr_name = attribute.to_s.tr(".", "_").humanize
       attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
-      I18n.t(:"errors.format",         default:  "%{attribute} %{message}",
+      I18n.t(:"errors.format",
+        default:  "%{attribute} %{message}",
         attribute: attr_name,
         message:   message)
     end

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -55,7 +55,8 @@ class ConfirmationValidationTest < ActiveModel::TestCase
       @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
       I18n.load_path.clear
       I18n.backend = I18n::Backend::Simple.new
-      I18n.backend.store_translations("en",         errors: { messages: { confirmation: "doesn't match %{attribute}" } },
+      I18n.backend.store_translations("en",
+        errors: { messages: { confirmation: "doesn't match %{attribute}" } },
         activemodel: { attributes: { topic: { title: "Test Title"} } })
 
       Topic.validates_confirmation_of(:title)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   RecordNotFound raised by association.find exposes `id`, `primary_key` and
+    `model` methods to be consistent with RecordNotFound raised by Record.find.
+
+    *Michel Pigassou*
+
 *   Hashes can once again be passed to setters of `composed_of`, if all of the
     mapping methods are methods implemented on `Hash`.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -47,7 +47,9 @@
     *Xavier Noria*
 
 *   Using `group` with an attribute that has a custom type will properly cast
-    the hash keys after calling a calculation method like `count`. Fixes #25595.
+    the hash keys after calling a calculation method like `count`. 
+    
+    Fixes #25595.
 
     *Sean Griffin*
 
@@ -81,6 +83,7 @@
     *Sean Griffin*
 
 *   Ensure hashes can be assigned to attributes created using `composed_of`.
+    
     Fixes #25210.
 
     *Sean Griffin*
@@ -100,7 +103,7 @@
 
     *Erol Fornoles*
 
-*   PostgreSQL: Fix db:structure:load silent failure on SQL error.
+*   PostgreSQL: Fix `db:structure:load` silent failure on SQL error.
 
     The command line flag `-v ON_ERROR_STOP=1` should be used
     when invoking `psql` to make sure errors are not suppressed.

--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
-COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+
 module Minitest
   def self.plugin_active_record_options(opts, options)
     opts.separator ""

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1208,7 +1208,7 @@ module ActiveRecord
             checks << lambda { |i| i.columns.join("_and_") == column_names.join("_and_") }
           end
 
-          raise ArgumentError "No name or columns specified" if checks.none?
+          raise ArgumentError, "No name or columns specified" if checks.none?
 
           matching_indexes = indexes(table_name).select { |i| checks.all? { |check| check[i] } }
 

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -78,10 +78,12 @@ module ActiveRecord
 
           def raw_config
             if uri.opaque
-              query_hash.merge(              "adapter"  => @adapter,
+              query_hash.merge(
+                "adapter"  => @adapter,
                 "database" => uri.opaque)
             else
-              query_hash.merge(              "adapter"  => @adapter,
+              query_hash.merge(
+                "adapter"  => @adapter,
                 "username" => uri.user,
                 "password" => uri.password,
                 "port"     => uri.port,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -348,15 +348,17 @@ module ActiveRecord
     def raise_record_not_found_exception!(ids, result_size, expected_size) #:nodoc:
       conditions = arel.where_sql(@klass.arel_engine)
       conditions = " [#{conditions}]" if conditions
+      name = @klass.name
 
       if Array(ids).size == 1
-        error = "Couldn't find #{@klass.name} with '#{primary_key}'=#{ids}#{conditions}"
+        error = "Couldn't find #{name} with '#{primary_key}'=#{ids}#{conditions}"
+        raise RecordNotFound.new(error, name, primary_key, ids)
       else
-        error = "Couldn't find all #{@klass.name.pluralize} with '#{primary_key}': "
+        error = "Couldn't find all #{name.pluralize} with '#{primary_key}': "
         error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})"
-      end
 
-      raise RecordNotFound, error
+        raise RecordNotFound, error
+      end
     end
 
     private

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -81,6 +81,12 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     assert_equal expected, remove_index(:people, name: "index_people_on_last_name", algorithm: :concurrently)
   end
 
+  def test_remove_index_with_wrong_option
+    assert_raises ArgumentError do
+      remove_index(:people, coulmn: :last_name)
+    end
+  end
+
   private
     def method_missing(method_symbol, *arguments)
       ActiveRecord::Base.connection.send(method_symbol, *arguments)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -283,7 +283,8 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_habtm_collection_size_from_params
-    devel = Developer.new(      projects_attributes: {
+    devel = Developer.new(
+      projects_attributes: {
         "0" => {}
       })
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -618,6 +618,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { firm.clients.find(2, 99) }
   end
 
+  def test_find_one_message_on_primary_key
+    firm = Firm.all.merge!(order: "id").first
+
+    e = assert_raises(ActiveRecord::RecordNotFound) do
+      firm.clients.find(0)
+    end
+    assert_equal 0, e.id
+    assert_equal "id", e.primary_key
+    assert_equal "Client", e.model
+    assert_match (/\ACouldn't find Client with 'id'=0/), e.message
+  end
+
   def test_find_ids_and_inverse_of
     force_signal37_to_load_all_clients_of_firm
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -279,7 +279,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_initialize_with_attributes
-    topic = Topic.new(      "title" => "initialized from attributes", "written_on" => "2003-12-12 23:23")
+    topic = Topic.new(
+      "title" => "initialized from attributes", "written_on" => "2003-12-12 23:23")
 
     assert_equal("initialized from attributes", topic.title)
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1119,6 +1119,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [0, 1, 1], posts.map(&:author_id).sort
   end
 
+  def test_find_one_message_on_primary_key
+    e = assert_raises(ActiveRecord::RecordNotFound) do
+      Car.find(0)
+    end
+    assert_equal 0, e.id
+    assert_equal "id", e.primary_key
+    assert_equal "Car", e.model
+    assert_equal "Couldn't find Car with 'id'=0", e.message
+  end
+
   def test_find_one_message_with_custom_primary_key
     table_with_custom_primary_key do |model|
       model.primary_key = :name

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -280,7 +280,7 @@ class FixturesTest < ActiveRecord::TestCase
   end
 end
 
-class HasManyThroughFixture < ActiveSupport::TestCase
+class HasManyThroughFixture < ActiveRecord::TestCase
   def make_model(name)
     Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }
   end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -596,7 +596,8 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   def test_should_save_only_one_association_on_create
-    pirate = Pirate.create!(      :catchphrase => "Arr",
+    pirate = Pirate.create!(
+      :catchphrase => "Arr",
       association_getter => { "foo" => { name: "Grace OMalley" } })
 
     assert_equal 1, pirate.reload.send(@association_name).count

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -967,7 +967,8 @@ class PersistenceTest < ActiveRecord::TestCase
         self.table_name = :widgets
       end
 
-      instance  = widget.create!(        name: "Bob",
+      instance  = widget.create!(
+        name: "Bob",
         created_at: 1.day.ago,
         updated_at: 1.day.ago)
 

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require "models/post"
 
 module ActiveRecord
-  class RelationMutationTest < ActiveSupport::TestCase
+  class RelationMutationTest < ActiveRecord::TestCase
     class FakeKlass < Struct.new(:table_name, :name)
       extend ActiveRecord::Delegation::DelegateCache
       inherited self

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -246,7 +246,7 @@ class NestedRelationScopingTest < ActiveRecord::TestCase
         devs = Developer.all
         sql = devs.to_sql
         assert_match "(salary = 80000)", sql
-        assert_match /LIMIT 10|ROWNUM <= 10|FETCH FIRST 10 ROWS ONLY/, sql
+        assert_match(/LIMIT 10|ROWNUM <= 10|FETCH FIRST 10 ROWS ONLY/, sql)
       end
     end
   end

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -156,17 +156,15 @@ class ValidationsTest < ActiveRecord::TestCase
   end
 
   def test_numericality_validation_with_mutation
-    Topic.class_eval do
+    klass = Class.new(Topic) do
       attribute :wibble, :string
       validates_numericality_of :wibble, only_integer: true
     end
 
-    topic = Topic.new(wibble: "123-4567")
+    topic = klass.new(wibble: "123-4567")
     topic.wibble.gsub!("-", "")
 
     assert topic.valid?
-  ensure
-    Topic.reset_column_information
   end
 
   def test_acceptance_validator_doesnt_require_db_connection

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -40,10 +40,10 @@
 
     *Xavier Noria*
 
-*   Allow MessageEncryptor to take advantage of authenticated encryption modes.
+*   Allow `MessageEncryptor` to take advantage of authenticated encryption modes.
 
     AEAD modes like `aes-256-gcm` provide both confidentiality and data
-    authenticity, eliminating the need to use MessageVerifier to check if the
+    authenticity, eliminating the need to use `MessageVerifier` to check if the
     encrypted data has been tampered with. This speeds up encryption/decryption
     and results in shorter cipher text.
 
@@ -147,7 +147,7 @@
 
     *Sean Griffin*
 
-*   Introduce Module#delegate_missing_to.
+*   Introduce `Module#delegate_missing_to`.
 
     When building a decorator, a common pattern emerges:
 

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+
 exit Minitest.run(ARGV)

--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -28,6 +28,8 @@ module ActiveSupport
       end
     end
 
+    # Declares a block that will be executed when a Rails component is fully
+    # loaded.
     def on_load(name, options = {}, &block)
       @loaded[name].each do |base|
         execute_hook(base, options, block)

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -54,7 +54,8 @@ module RailsGuides
       end
 
       def engine
-        @engine ||= Redcarpet::Markdown.new(Renderer,           no_intra_emphasis: true,
+        @engine ||= Redcarpet::Markdown.new(Renderer,
+          no_intra_emphasis: true,
           fenced_code_blocks: true,
           autolink: true,
           strikethrough: true,

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -313,7 +313,7 @@ App.cable.subscriptions.create { channel: "ChatChannel", room: "Best Room" },
 ```ruby
 # Somewhere in your app this is called, perhaps
 # from a NewCommentJob.
-ChatChannel.broadcast_to(
+ActionCable.server.broadcast(
   "chat_#{room}",
   sent_by: 'Paul',
   body: 'This is a cool chat app.'

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -242,10 +242,10 @@ WebNotificationsChannel.broadcast_to(
 The `WebNotificationsChannel.broadcast_to` call places a message in the current
 subscription adapter (Redis by default)'s pubsub queue under a separate
 broadcasting name for each user. For a user with an ID of 1, the broadcasting
-name would be `web_notifications_1`.
+name would be `web_notifications:1`.
 
 The channel has been instructed to stream everything that arrives at
-`web_notifications_1` directly to the client by invoking the `received`
+`web_notifications:1` directly to the client by invoking the `received`
 callback.
 
 ### Subscriptions

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -416,7 +416,6 @@ the Active Model API.
     ```ruby
     class Person
       include ActiveModel::Model
-
     end
     ```
 
@@ -467,7 +466,7 @@ In order to make this work, the model must have an accessor named `password_dige
 The `has_secure_password` will add the following validations on the `password` accessor:
 
 1. Password should be present.
-2. Password should be equal to its confirmation.
+2. Password should be equal to its confirmation (provided +password_confirmation+ is passed along).
 3. The maximum length of a password is 72 (required by `bcrypt` on which ActiveModel::SecurePassword depends)
 
 #### Examples
@@ -492,6 +491,10 @@ person.valid? # => false
 # When the length of password exceeds 72.
 person.password = person.password_confirmation = 'a' * 100
 person.valid? # => false
+
+# When only password is supplied with no password_confirmation.
+person.password = 'aditya'
+person.valid? # => true
 
 # When all validations are passed.
 person.password = person.password_confirmation = 'aditya'

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -512,6 +512,30 @@ class ProductsController < ApplicationController
 end
 ```
 
+Sometimes we want to cache response, for example a static page, that never gets
+expired. To achieve this, we can use `http_cache_forever` helper and by doing
+so browser and proxies will cache it indefinitely.
+
+By default cached responses will be private, cached only on the user's web
+browser. To allow proxies to cache the response, set `public: true` to indicate
+that they can serve the cached response to all users.
+
+Using this helper, `last_modified` header is set to `Time.new(2011, 1, 1).utc`
+and `expires` header is set to a 100 years.
+
+WARNING: Use this method carefully as browser/proxy won't be able to invalidate
+the cached response unless browser cache is forcefully cleared.
+
+```ruby
+class HomeController < ApplicationController
+  def index
+    http_cache_forever(public: true) do
+      render
+    end
+  end
+end
+```
+
 ### Strong v/s Weak ETags
 
 Rails generates weak ETags by default. Weak ETags allow semantically equivalent

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -88,7 +88,8 @@ module Rails
     end
 
     def default_options
-      super.merge(        Port:               ENV.fetch("PORT", 3000).to_i,
+      super.merge(
+        Port:               ENV.fetch("PORT", 3000).to_i,
         Host:               ENV.fetch("HOST", "localhost").dup,
         DoNotReverseLookup: true,
         environment:        (ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development").dup,

--- a/railties/lib/rails/engine/commands_tasks.rb
+++ b/railties/lib/rails/engine/commands_tasks.rb
@@ -103,6 +103,8 @@ In addition to those commands, there are:
         end
 
         def rake_tasks
+          require_rake
+
           return @rake_tasks if defined?(@rake_tasks)
 
           load_generators

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -324,6 +324,7 @@ module Rails
           remove_file "app/mailers/application_mailer.rb"
           remove_file "app/views/layouts/mailer.html.erb"
           remove_file "app/views/layouts/mailer.text.erb"
+          remove_dir "app/mailers"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -18,7 +18,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
+      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => 'public, max-age=3600'
+    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/railties/test/engine/commands_tasks_test.rb
+++ b/railties/test/engine/commands_tasks_test.rb
@@ -1,0 +1,24 @@
+require "abstract_unit"
+
+class Rails::Engine::CommandsTasksTest < ActiveSupport::TestCase
+  def setup
+    @destination_root = Dir.mktmpdir("bukkits")
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+  end
+
+  def teardown
+    FileUtils.rm_rf(@destination_root)
+  end
+
+  def test_help_command_work_inside_engine
+    output = capture(:stderr) do
+      Dir.chdir(plugin_path) { `bin/rails --help` }
+    end
+    assert_no_match "NameError", output
+  end
+
+  private
+    def plugin_path
+      "#{@destination_root}/bukkits"
+    end
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -380,6 +380,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/environments/production.rb" do |content|
       assert_no_match(/config\.action_mailer/, content)
     end
+    assert_no_directory "app/mailers"
   end
 
   def test_generator_has_assets_gems

--- a/railties/test/json_params_parsing_test.rb
+++ b/railties/test/json_params_parsing_test.rb
@@ -1,0 +1,47 @@
+require "abstract_unit"
+require "action_dispatch"
+require "active_record"
+
+class JsonParamsParsingTest < ActionDispatch::IntegrationTest
+  test "prevent null query" do
+    # Make sure we have data to find
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; 'Foo'; end
+      establish_connection adapter: "sqlite3", database: ":memory:"
+      connection.create_table "foos" do |t|
+        t.string :title
+        t.timestamps null: false
+      end
+    end
+    klass.create
+    assert klass.first
+
+    app = ->(env) {
+      request = ActionDispatch::Request.new env
+      params = ActionController::Parameters.new request.parameters
+      if params[:t]
+        klass.find_by_title(params[:t])
+      else
+        nil
+      end
+    }
+
+    assert_nil app.call(make_env({ 't' => nil }))
+    assert_nil app.call(make_env({ 't' => [nil] }))
+
+    [[[nil]], [[[nil]]]].each do |data|
+      assert_nil app.call(make_env({ 't' => data }))
+    end
+  end
+
+  private
+    def make_env json
+      data = JSON.dump json
+      content_length = data.length
+      {
+        'CONTENT_LENGTH' => content_length,
+        'CONTENT_TYPE'   => 'application/json',
+        'rack.input'     => StringIO.new(data)
+      }
+    end
+end


### PR DESCRIPTION
### Changelog

> RecordNotFound raised by association.find exposes `id`, `primary_key` and
>     `model` methods to be consistent with RecordNotFound raised by Record.find.
### Summary

`RecordNotFound` reference when doing `Car.find(0)`:

```
(byebug) exception.inspect
"#<ActiveRecord::RecordNotFound: Couldn't find Car with 'id'=0>"
(byebug) exception.id
0
(byebug) exception.primary_key
"id"
(byebug) exception.model
"Car"
```

Before code change when doing `association.find(0)`:

```
(byebug) exception.inspect
"#<ActiveRecord::RecordNotFound: Couldn't find Client with 'id'=0 [WHERE \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient') AND \"companies\".\"firm_id\" = ? AND \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient')]>"
(byebug) exception.id
nil
(byebug) exception.model
nil
(byebug) exception.primary_key
nil
```

After code change when doing `association.find(0)`:

```
(byebug) exception.inspect
"#<ActiveRecord::RecordNotFound: Couldn't find Client with 'id'=0 [WHERE \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient') AND \"companies\".\"firm_id\" = ? AND \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient')]>"
(byebug) exception.id
0
(byebug) exception.primary_key
"id"
(byebug) exception.model
"Client"
```
